### PR TITLE
Fix CI npm publishing as Trusted Publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,14 +27,13 @@ jobs:
         with:
           node-version: '20.x'
           cache: yarn
-          always-auth: true
+          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build app
         run: yarn build
       - name: Publish release on NPM
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc && \
           yarn publish \
             --tag latest \
             --access public


### PR DESCRIPTION
https://github.com/oasisprotocol/ionic-ledger-hw-transport-ble/pull/21 still didn't work.
Maybe this will.. Didn't check by publishing spam on another account tho. And there's no other way to check if this works