### PR TITLE
Increase browser support (ignore some errors, remove getConnectedDevices)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisprotocol/ionic-ledger-hw-transport-ble",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "description": "Ledger Hardware Wallet Bluetooth BLE transport for Ionic",
   "keywords": [
     "Ledger",

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,6 @@ export default class BleTransport extends Transport {
     try {
       // Similar to TransportWebUSB.create > TransportWebUSB.listen > getFirstLedgerDevice > navigator.usb.getDevices[0] || navigator.usb.requestDevice
       const scanResult =
-        (await bleInstance().getConnectedDevices(getBluetoothServiceUuids()))?.[0] || // If not `BleTransport.disconnect`-ed yet
         previousScanResult || // If disconnected but device is still findable
         (await bleInstance().requestDevice({ services: getBluetoothServiceUuids() })); // Shows native device selection UI
       log(TAG, `BLE device selected: ${scanResult.deviceId}`);


### PR DESCRIPTION
previousScanResult+requestDevice behave pretty much the same as getConnectedDevices+previousScanResult+requestDevice; theoretically there are rare additional cases now where it asks user to select bluetooth device again, but that's negligible